### PR TITLE
fix: basic server ports conflict

### DIFF
--- a/load-generator/src/main/resources/application.properties
+++ b/load-generator/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=load-generator
+server.port=8081


### PR DESCRIPTION
Ran into the issue, that port 8080 was occupied when running both servers `test-manager` & `load-generator` locally.