### PR TITLE
fix: Fixed opensearch url

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 ---
 # Test Data Generator Configuration
 DATA_GENERATION_MODE=dynamic
-OPENSEARCH_URL=http://localhost:9200
+OPENSEARCH_URL=http://test-target-opensearch:9200/
 
 # Logging Configuration
 LOGGING_LVL_ROOT=ERROR

--- a/load-generator/src/main/java/com/opensearchloadtester/loadgenerator/controller/LoadTestController.java
+++ b/load-generator/src/main/java/com/opensearchloadtester/loadgenerator/controller/LoadTestController.java
@@ -1,11 +1,6 @@
 package com.opensearchloadtester.loadgenerator.controller;
 
-import com.opensearchloadtester.loadgenerator.service.NoOpQueryExecution;
-import com.opensearchloadtester.loadgenerator.service.QueryExecution;
-import com.opensearchloadtester.loadgenerator.service.QueryExecutionFactory;
-import com.opensearchloadtester.loadgenerator.service.LoadRunnerService;
-import com.opensearchloadtester.loadgenerator.service.OpenSearchQueryExecution;
-import com.opensearchloadtester.loadgenerator.service.QueryRegistry;
+import com.opensearchloadtester.loadgenerator.service.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -18,13 +13,13 @@ import java.util.Map;
 /**
  * REST controller for triggering load tests and ad-hoc query runs
  * against OpenSearch.
- *
+ * <p>
  * Endpoints:
  * - POST /api/load-test/start : demo endpoint using NoOpQueryExecution
  * - POST /api/load-test/run   : real endpoint executing JSON template-based queries
  * - GET  /api/load-test/queries : list available queryIds from QueryRegistry
  * - GET  /api/load-test/health  : basic health check
- *
+ * <p>
  * It delegates the actual parallel execution to LoadRunnerService.
  */
 @Slf4j
@@ -34,7 +29,7 @@ public class LoadTestController {
 
     private final LoadRunnerService loadRunnerService;
     private final QueryRegistry queryRegistry;
-    @Value("${opensearchserver.url}")
+    @Value("${opensearch.url}")
     private String openSearchBaseUrl;
 
     public LoadTestController(LoadRunnerService loadRunnerService,
@@ -80,7 +75,7 @@ public class LoadTestController {
      *
      */
     @PostMapping("/run")
-    public ResponseEntity<String> runQuery(@RequestBody(required = false) QueryRunRequest request){
+    public ResponseEntity<String> runQuery(@RequestBody(required = false) QueryRunRequest request) {
         // Basic null check on request body
         if (request == null) {
             return ResponseEntity.badRequest().body("Request body must not be null\n");
@@ -170,7 +165,6 @@ public class LoadTestController {
         log.debug("Query run {} finished successfully", queryId);
         return ResponseEntity.ok("Query run finished successfully\n");
     }
-
 
 
     /**

--- a/load-generator/src/main/java/com/opensearchloadtester/loadgenerator/service/OpenSearchQueryExecution.java
+++ b/load-generator/src/main/java/com/opensearchloadtester/loadgenerator/service/OpenSearchQueryExecution.java
@@ -5,14 +5,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+
 /**
  * Executes a single OpenSearch search request based on a JSON template.
- *
+ * <p>
  * Responsibilities:
  * - Load the query template JSON from classpath (resources/queries).
  * - Replace {{placeholders}} with runtime parameters.
@@ -29,7 +33,7 @@ public class OpenSearchQueryExecution implements QueryExecution {
     private final Map<String, String> params;
     ObjectMapper mapper = new ObjectMapper();
 
-    @Value("${opensearchserver.url}")
+    @Value("${opensearch.url}")
     String openSearchBaseUrl;
 
     public OpenSearchQueryExecution(String id,
@@ -61,7 +65,6 @@ public class OpenSearchQueryExecution implements QueryExecution {
             }
 
             // 3) Prepare HTTP call to OpenSearchç
-
 
 
             String url = openSearchBaseUrl + indexName + "/_search";

--- a/load-generator/src/main/resources/application.properties
+++ b/load-generator/src/main/resources/application.properties
@@ -5,5 +5,4 @@ logging.level.com.opensearchloadtester.loadgenerator=INFO
 logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss}){faint} %clr(%5p) --- [%10.10t] %clr(%-40.40logger{39}){cyan} : %m%n
 server.port=8081
 logging.level.com.opensearchloadtester=INFO
-opensearch.url=http://localhost:8080/
-opensearchserver.url=http://localhost:9200/
+opensearch.url=http://localhost:9200/


### PR DESCRIPTION
### Changed URL of opensearch 
Now communication between load-generator and opensearch works when executing in docker containers.