### PR TITLE
Refactor/ metrics reporter

### DIFF
--- a/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/controller/ReportController.java
+++ b/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/controller/ReportController.java
@@ -1,7 +1,7 @@
 package com.opensearchloadtester.metricsreporter.controller;
 
 import com.opensearchloadtester.common.dto.MetricsDto;
-import com.opensearchloadtester.metricsreporter.dto.LoadTestSummaryDto;
+import com.opensearchloadtester.metricsreporter.dto.StatisticsDto;
 import com.opensearchloadtester.metricsreporter.service.ReportService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,7 +73,7 @@ public class ReportController {
         }
 
         loadGeneratorIds.add(payloadLoadGeneratorId);
-        log.info("Received {} metrics entries from load generators: {}", metricsList.size(), loadGeneratorIds);
+        log.info("Received {} metrics entries from load generator: {}", metricsList.size(), payloadLoadGeneratorId);
 
         // Immediately process and persist metrics to avoid unbounded in-memory growth
         try {
@@ -99,7 +99,7 @@ public class ReportController {
             log.info("All {} replicas have reported. Generating reports...", expectedReplicas);
 
             try {
-                LoadTestSummaryDto summary = reportService.finalizeReports(reportedInstances);
+                StatisticsDto summary = reportService.finalizeReports(reportedInstances);
 
                 StringBuilder message = new StringBuilder(String.format(
                         "All metrics received (%d/%d replicas). Reports generated successfully!\n" +

--- a/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/dto/StatisticsDto.java
+++ b/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/dto/StatisticsDto.java
@@ -2,7 +2,6 @@ package com.opensearchloadtester.metricsreporter.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.opensearchloadtester.common.dto.MetricsDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,27 +10,30 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 /**
- * Represents a complete test run report containing all query results.
- * This is the main report structure that can be exported to JSON or CSV.
+ * Represents aggregated statistics for a load test run.
+ * Kept separate from the full summary to match the dedicated statistics file.
  */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonPropertyOrder({
         "report_generated_at",
-        "statistics",
+        "request_duration_ms",
+        "query_duration_ms",
         "total_queries",
         "total_errors",
-        "query_results",
         "load_generator_instances"
 })
-public class LoadTestSummaryDto {
-
-    @JsonProperty("statistics")
-    private Statistics statistics;
+public class StatisticsDto {
 
     @JsonProperty("report_generated_at")
     private LocalDateTime reportGeneratedAt;
+
+    @JsonProperty("request_duration_ms")
+    private DurationStats requestDurationMs;
+
+    @JsonProperty("query_duration_ms")
+    private DurationStats queryDurationMs;
 
     @JsonProperty("total_queries")
     private Integer totalQueries;
@@ -39,22 +41,8 @@ public class LoadTestSummaryDto {
     @JsonProperty("total_errors")
     private Integer totalErrors;
 
-    @JsonProperty("query_results")
-    private List<MetricsDto> queryResults;
-
     @JsonProperty("load_generator_instances")
     private List<String> loadGeneratorInstances;
-
-    @Data
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Statistics {
-        @JsonProperty("request_duration_ms")
-        private DurationStats requestDurationMs;
-
-        @JsonProperty("query_duration_ms")
-        private DurationStats queryDurationMs;
-    }
 
     @Data
     @NoArgsConstructor

--- a/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/service/ReportService.java
+++ b/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/service/ReportService.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.opensearchloadtester.common.dto.MetricsDto;
-import com.opensearchloadtester.metricsreporter.dto.LoadTestSummaryDto;
+import com.opensearchloadtester.metricsreporter.dto.StatisticsDto;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
@@ -193,30 +193,22 @@ public class ReportService {
     }
 
     /**
-     * Finalizes reports by writing a summary JSON without loading all query results into memory.
+     * Finalizes reports by writing the aggregated statistics JSON and building the full query results JSON
+     * without loading all query results into memory.
      */
-    public synchronized LoadTestSummaryDto finalizeReports(Set<String> loadGeneratorInstances) throws IOException {
+    public synchronized StatisticsDto finalizeReports(Set<String> loadGeneratorInstances) throws IOException {
         initializeReportFiles();
 
-        LoadTestSummaryDto.Statistics statistics = stats.toStatistics();
-
-        LoadTestSummaryDto report = new LoadTestSummaryDto(
-                statistics,
-                LocalDateTime.now(),
-                stats.getTotalQueries(),
-                stats.getTotalErrors(),
-                new ArrayList<>(), // omit query_results to stay lean
-                new ArrayList<>(loadGeneratorInstances)
-        );
+        StatisticsDto statistics = stats.toStatistics(LocalDateTime.now(), loadGeneratorInstances);
 
         Path statsPath = Paths.get(outputDirectory, statsFilename);
-        objectMapper.writeValue(statsPath.toFile(), report);
+        objectMapper.writeValue(statsPath.toFile(), statistics);
         Path ndjsonPath = Paths.get(outputDirectory, ndjsonFilename);
         Path fullJsonPath = Paths.get(outputDirectory, fullJsonFilename);
         writeFullJsonReport(ndjsonPath, fullJsonPath);
         deleteNdjsonFile(ndjsonPath);
 
-        log.info("Summary written: queries={}, errors={}, instances={}", report.getTotalQueries(), report.getTotalErrors(), report.getLoadGeneratorInstances().size());
+        log.info("Statistics written: queries={}, errors={}, instances={}", statistics.getTotalQueries(), statistics.getTotalErrors(), statistics.getLoadGeneratorInstances().size());
         log.info("Request duration stats: avg={}ms min={}ms max={}ms | Query duration stats: avg={}ms min={}ms max={}ms",
                 String.format("%.2f", statistics.getRequestDurationMs().getAverage()),
                 statistics.getRequestDurationMs().getMin(),
@@ -225,7 +217,7 @@ public class ReportService {
                 statistics.getQueryDurationMs().getMin(),
                 statistics.getQueryDurationMs().getMax());
 
-        return report;
+        return statistics;
     }
 
     /**
@@ -311,8 +303,8 @@ public class ReportService {
             }
         }
 
-        LoadTestSummaryDto.Statistics toStatistics() {
-            LoadTestSummaryDto.DurationStats requestDuration = new LoadTestSummaryDto.DurationStats();
+        StatisticsDto toStatistics(LocalDateTime generatedAt, Set<String> loadGeneratorInstances) {
+            StatisticsDto.DurationStats requestDuration = new StatisticsDto.DurationStats();
             if (requestDurationCount > 0) {
                 requestDuration.setAverage(requestDurationSum / (double) requestDurationCount);
                 requestDuration.setMin(requestDurationMin);
@@ -323,7 +315,7 @@ public class ReportService {
                 requestDuration.setMax(0L);
             }
 
-            LoadTestSummaryDto.DurationStats queryDuration = new LoadTestSummaryDto.DurationStats();
+            StatisticsDto.DurationStats queryDuration = new StatisticsDto.DurationStats();
             if (queryDurationCount > 0) {
                 queryDuration.setAverage(queryDurationSum / (double) queryDurationCount);
                 queryDuration.setMin(queryDurationMin);
@@ -334,7 +326,14 @@ public class ReportService {
                 queryDuration.setMax(0L);
             }
 
-            return new LoadTestSummaryDto.Statistics(requestDuration, queryDuration);
+            return new StatisticsDto(
+                    generatedAt,
+                    requestDuration,
+                    queryDuration,
+                    totalQueries,
+                    totalErrors,
+                    new ArrayList<>(loadGeneratorInstances)
+            );
         }
     }
 }


### PR DESCRIPTION
- Statistik-Teil aus LoadTestSummaryDto entfernt und neues StatisticsDto eingeführt, das die Statistikdatei direkt abbildet.

- ReportService.finalizeReports liefert nun StatisticsDto, schreibt nur die Statistik-JSON und streamt NDJSON → query_results.json.

- ReportController auf den neuen DTO-Rückgabetyp umgestellt; Statistik-JSON liegt jetzt flach (kein verschachteltes statistics-Objekt).