### PR TITLE
github: new rule merges into main only from dev

### DIFF
--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -1,0 +1,18 @@
+name: Check Branch
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block non-dev merges to main
+        if: ${{ github.event.pull_request.base.ref == 'main'
+          && github.event.pull_request.head.ref != 'dev'
+          && !contains(github.event.pull_request.head.ref, 'po-deliverables') }}
+        run: |
+          echo "ERROR: You can only merge to main from dev or branches containing 'po-deliverables'."
+          exit 1


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce branch protection rules for merges into the `main` branch. The workflow ensures that only merges from the `dev` branch or branches containing `po-deliverables` are permitted.

Branch protection automation:

* Added `.github/workflows/check-branch.yml` to block pull requests that attempt to merge into `main` from any branch other than `dev` or branches containing `po-deliverables`, helping maintain a controlled release process.