### PR TITLE
fix: improved LoadRunner termination mechanism

### DIFF
--- a/load-generator/src/main/java/com/opensearchloadtester/loadgenerator/service/LoadRunner.java
+++ b/load-generator/src/main/java/com/opensearchloadtester/loadgenerator/service/LoadRunner.java
@@ -54,7 +54,7 @@ public class LoadRunner {
         // Track overall test start time
         long testStartTime = System.currentTimeMillis();
 
-        ScheduledExecutorService executorService = Executors
+        ScheduledExecutorService scheduler = Executors
                 .newSingleThreadScheduledExecutor();
         ExecutorService workers = Executors.newCachedThreadPool();
 
@@ -66,8 +66,11 @@ public class LoadRunner {
             AtomicInteger queryCounter = new AtomicInteger();
             log.debug("Schedule delay:  {} ns  ", durationPerQuery);
 
+            // Signals when we have stopped scheduling new query submissions.
+            CountDownLatch schedulingStopped = new CountDownLatch(1);
+
             // Start scheduled query execution
-            ScheduledFuture<?> future = executorService.scheduleAtFixedRate(() -> {
+            ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(() -> {
                         try {
                             workers.submit(query);
                             queryCounter.getAndIncrement();
@@ -79,17 +82,28 @@ public class LoadRunner {
                     durationPerQuery / 2,
                     durationPerQuery,
                     TimeUnit.NANOSECONDS);
-            executorService.schedule(() -> future.cancel(false), durationNs, TimeUnit.NANOSECONDS);
+            // After the scenario duration, stop the periodic scheduling (already submitted tasks may still run).
+            scheduler.schedule(() -> {
+                try {
+                    future.cancel(false);
+                } finally {
+                    // Always unblock the main thread
+                    schedulingStopped.countDown();
+                }
+            }, durationNs, TimeUnit.NANOSECONDS);
 
-            // TODO: Wait for all threads to complete
-            log.info("Waiting for all threads to complete");
-            boolean completed = true;
-            executorService.awaitTermination(durationNs + 10_000_000_000L, TimeUnit.NANOSECONDS);
-            // TODO: Set a timeout per queryExecution
-            // boolean completed = latch.await(10, TimeUnit.MINUTES);
+            // Wait until the "stop scheduling" task has executed on main thread.
+            schedulingStopped.await();
+
+            // No new tasks from here: shutdown scheduler and let workers finish queued tasks.
+            scheduler.shutdown();
+            workers.shutdown();
+
+            log.info("Waiting for all worker threads to complete");
+            boolean completed = awaitExecutorServiceTermination(workers, "worker threads");
 
             // Check if QPS fulfilled
-            if (queryCounter.get() != qpsPerLoadGen * scenarioConfig.getDuration().toSeconds()) {
+            if (queryCounter.get() < qpsPerLoadGen * scenarioConfig.getDuration().toSeconds()) {
                 log.warn("Load Generator can't keep up with QPS... please increase REPLICA amount!");
             }
 
@@ -106,15 +120,18 @@ public class LoadRunner {
                         scenarioConfig.getDuration().getSeconds(),
                         String.format("%.2f", actualDurationSeconds));
             } else {
-                log.warn("Timeout waiting for execution threads to complete");
-                log.warn("Scenario '{}' did not complete within expected duration. Actual runtime: {}s",
+                log.warn("Scenario '{}' was interrupted while waiting for worker threads to finish. Actual runtime: {}s",
                         scenarioConfig.getName(), String.format("%.2f", actualDurationSeconds));
             }
 
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while executing scenario '{}'", scenarioConfig.getName(), e);
         } catch (Exception e) {
             log.error("Error executing queries:", e);
         } finally {
-            shutdownExecutorService(executorService);
+            shutdownExecutorService(scheduler);
+            shutdownExecutorService(workers);
         }
     }
 
@@ -137,6 +154,19 @@ public class LoadRunner {
             log.error("Interrupted while shutting down executor service", e);
             executorService.shutdownNow();
             Thread.currentThread().interrupt();
+        }
+    }
+
+    private boolean awaitExecutorServiceTermination(ExecutorService executorService, String executorName) {
+        try {
+            while (!executorService.awaitTermination(30, TimeUnit.SECONDS)) {
+                log.info("Still waiting for {} to complete...", executorName);
+            }
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while waiting for {} to complete", executorName, e);
+            return false;
         }
     }
 }


### PR DESCRIPTION
closes #136 

- Replaced the fixed “duration + offset” termination with a deterministic shutdown sequence.

- Added a scheduled stop task that cancels the periodic `scheduleAtFixedRate` after `durationNs`, so no new worker tasks are submitted after the test duration.
- Added a small synchronization barrier (`CountDownLatch`) to ensure the “stop scheduling” task has executed before shutting down the thread pools in the main thread.
- After scheduling stops, the code calls `scheduler.shutdown()` and `workers.shutdown()` and then waits until all queued worker tasks finish before reporting metrics.

_Do we really need this CountDownLatch?_
YES, we have to be sure that stop scheduling task was executed on the main thread before continuing!