### PR TITLE
Feature: #152 Shutdown Metrics Reporter after report generation

### DIFF
--- a/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/config/ShutdownAfterResponseInterceptor.java
+++ b/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/config/ShutdownAfterResponseInterceptor.java
@@ -1,0 +1,51 @@
+package com.opensearchloadtester.metricsreporter.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Shuts down the Metrics Reporter after the current HTTP request has fully completed.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ShutdownAfterResponseInterceptor implements HandlerInterceptor {
+
+    public static final String SHUTDOWN_AFTER_RESPONSE = "metricsReporter.shutdownAfterResponse";
+
+    private final ConfigurableApplicationContext context;
+    private final AtomicBoolean shutdownInitiated = new AtomicBoolean(false);
+
+    @Override
+    public void afterCompletion(HttpServletRequest request,
+                                HttpServletResponse response,
+                                Object handler,
+                                Exception ex) {
+
+        Object flag = request.getAttribute(SHUTDOWN_AFTER_RESPONSE);
+        boolean shouldShutdown = Boolean.TRUE.equals(flag);
+
+        if (!shouldShutdown) {
+            return;
+        }
+
+        if (!shutdownInitiated.compareAndSet(false, true)) {
+            return; // already shutting down
+        }
+
+        // Run shutdown outside request thread
+        new Thread(() -> {
+            log.info("Shutting down Metrics Reporter");
+            int exitCode = SpringApplication.exit(context, () -> 0);
+            System.exit(exitCode);
+        }, "metrics-reporter-shutdown").start();
+    }
+}

--- a/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/config/WebConfig.java
+++ b/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.opensearchloadtester.metricsreporter.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final ShutdownAfterResponseInterceptor shutdownInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(shutdownInterceptor);
+    }
+}

--- a/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/controller/ReportController.java
+++ b/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/controller/ReportController.java
@@ -1,8 +1,10 @@
 package com.opensearchloadtester.metricsreporter.controller;
 
 import com.opensearchloadtester.common.dto.MetricsDto;
+import com.opensearchloadtester.metricsreporter.config.ShutdownAfterResponseInterceptor;
 import com.opensearchloadtester.metricsreporter.dto.StatisticsDto;
 import com.opensearchloadtester.metricsreporter.service.ReportService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -44,7 +46,8 @@ public class ReportController {
      * @return ResponseEntity with status message
      */
     @PostMapping("/metrics")
-    public synchronized ResponseEntity<String> submitMetrics(@RequestBody List<MetricsDto> metricsList) {
+    public synchronized ResponseEntity<String> submitMetrics(@RequestBody List<MetricsDto> metricsList,
+                                                             HttpServletRequest request) {
         Set<String> loadGeneratorIds = new HashSet<>();
 
         // Validate payload (empty payload is invalid)
@@ -95,7 +98,7 @@ public class ReportController {
                 metricsList.size());
 
         // Check if all replicas have reported
-        if (currentCount >= expectedReplicas) {
+        if (currentCount == expectedReplicas) {
             log.info("All {} replicas have reported. Generating reports...", expectedReplicas);
 
             try {
@@ -118,9 +121,8 @@ public class ReportController {
                     message.append("CSV report: ").append(reportService.getCsvReportPath()).append("\n");
                 }
 
-                // Prepare for the next run without requiring a service restart.
-                reportedInstances.clear();
-                reportService.resetForNewRun();
+                // Mark request for application shutdown AFTER response completed
+                request.setAttribute(ShutdownAfterResponseInterceptor.SHUTDOWN_AFTER_RESPONSE, true);
 
                 return ResponseEntity.ok(message.toString());
 

--- a/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/service/ReportService.java
+++ b/metrics-reporter/src/main/java/com/opensearchloadtester/metricsreporter/service/ReportService.java
@@ -124,16 +124,6 @@ public class ReportService {
         }
     }
 
-    /**
-     * Resets in-memory state so a new load test can be executed without restarting the service.
-     * Report files are cleaned up lazily on the next incoming metrics batch.
-     */
-    public synchronized void resetForNewRun() {
-        stats.reset();
-        filesInitialized = false;
-    }
-
-
     private void appendToCsvReport(List<MetricsDto> metricsList) throws IOException {
         Path csvPath = Paths.get(outputDirectory, csvFilename);
 
@@ -299,21 +289,6 @@ public class ReportService {
         private long queryDurationSum = 0;
         private long queryDurationMin = Long.MAX_VALUE;
         private long queryDurationMax = Long.MIN_VALUE;
-
-        void reset() {
-            totalQueries = 0;
-            totalErrors = 0;
-
-            requestDurationCount = 0;
-            requestDurationSum = 0;
-            requestDurationMin = Long.MAX_VALUE;
-            requestDurationMax = Long.MIN_VALUE;
-
-            queryDurationCount = 0;
-            queryDurationSum = 0;
-            queryDurationMin = Long.MAX_VALUE;
-            queryDurationMax = Long.MIN_VALUE;
-        }
 
         void update(List<MetricsDto> results) {
             for (MetricsDto result : results) {


### PR DESCRIPTION
closes backlog item #152 

**Note:** To ensure the **Metrics Reporter** doesn't shut down before the HTTP response is sent back to the last **Load Generator**, a `HandlerInterceptor` was added to the request lifecycle.