### PR TITLE
chore(pom): update to version 6.0.0

### DIFF
--- a/common-core/pom.xml
+++ b/common-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.opensearchloadtester</groupId>
         <artifactId>opensearch-load-tester-parent</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/load-generator/pom.xml
+++ b/load-generator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.opensearchloadtester</groupId>
         <artifactId>opensearch-load-tester-parent</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/metrics-reporter/pom.xml
+++ b/metrics-reporter/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.opensearchloadtester</groupId>
         <artifactId>opensearch-load-tester-parent</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.opensearchloadtester</groupId>
     <artifactId>opensearch-load-tester-parent</artifactId>
-    <version>5.1.0</version>
+    <version>6.0.0</version>
     <packaging>pom</packaging>
 
     <name>opensearch-load-tester-parent</name>

--- a/testdata-generator/pom.xml
+++ b/testdata-generator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.opensearchloadtester</groupId>
         <artifactId>opensearch-load-tester-parent</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.opensearchloadtester</groupId>
         <artifactId>opensearch-load-tester-parent</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.opensearchloadtester</groupId>
             <artifactId>loadgenerator</artifactId>
-            <version>5.1.0</version>
+            <version>6.0.0</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
This pull request updates the version of the parent Maven project and all related modules from 5.1.0 to 6.0.0. This ensures consistency across the project and prepares all modules to use the new parent version.
