### PR TITLE
Fix/265 check po ms

### DIFF
--- a/load-generator/pom.xml
+++ b/load-generator/pom.xml
@@ -12,7 +12,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>loadgenerator</artifactId>
+    <artifactId>load-generator</artifactId>
     <name>load-generator</name>
 
     <dependencies>

--- a/metrics-reporter/pom.xml
+++ b/metrics-reporter/pom.xml
@@ -12,7 +12,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>metricsreporter</artifactId>
+    <artifactId>metrics-reporter</artifactId>
     <name>metrics-reporter</name>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
             <dependency>
                 <groupId>com.opensearchloadtester</groupId>
-                <artifactId>loadgenerator</artifactId>
+                <artifactId>load-generator</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/testdata-generator/pom.xml
+++ b/testdata-generator/pom.xml
@@ -12,7 +12,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>testdatagenerator</artifactId>
+    <artifactId>testdata-generator</artifactId>
     <name>testdata-generator</name>
 
     <dependencies>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -50,7 +50,7 @@
 
         <dependency>
             <groupId>com.opensearchloadtester</groupId>
-            <artifactId>loadgenerator</artifactId>
+            <artifactId>load-generator</artifactId>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
closes #265 

## Summary
- Add missing modules (`metrics-reporter`, `testdata-generator`) to parent POM
- Centralize internal dependency versioning via `dependencyManagement` using `${project.version}`
- Remove hardcoded version `6.0.0` from `ui/pom.xml` load-generator dependency
- Simplify `maven-compiler-plugin` in `ui/pom.xml` to inherit from parent
- Remove redundant `project.build.sourceEncoding` property (inherited from parent)
- Align artifactIds with module folder names for consistency:
  - `loadgenerator` → `load-generator`
  - `metricsreporter` → `metrics-reporter`
  - `testdatagenerator` → `testdata-generator`

## Tesed
- [ ] Run `mvn clean install` to verify build succeeds
- [ ] Verify all modules are built in correct order
- [ ] Confirm all tests pass
- [ ] Check Docker builds still work with renamed JARs

**BREAKING CHANGE:** Maven coordinates changed. Local caches need to be cleared.
Run `mvn clean install`
