### PR TITLE
hotfix: duoBookingByCostcenter fixed

### DIFF
--- a/common-core/pom.xml
+++ b/common-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.opensearchloadtester</groupId>
         <artifactId>opensearch-load-tester-parent</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/load-generator/pom.xml
+++ b/load-generator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.opensearchloadtester</groupId>
         <artifactId>opensearch-load-tester-parent</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/load-generator/src/main/java/com/opensearchloadtester/loadgenerator/queries/DuoBookingByCostcenterAndDateQuery.java
+++ b/load-generator/src/main/java/com/opensearchloadtester/loadgenerator/queries/DuoBookingByCostcenterAndDateQuery.java
@@ -13,9 +13,11 @@ public class DuoBookingByCostcenterAndDateQuery extends AbstractQuery {
 
     String fromYear = getRandomYear();
     String toYear = getRandomYearAfter(fromYear);
+    String costCenter1 = "cc-" + faker().number().numberBetween(0, 10_000);
 
     Map<String, String> queryParams =
         Map.of(
+            "cost_center_1", costCenter1,
             "date_from", fromYear,
             "date_to", toYear);
 

--- a/metrics-reporter/pom.xml
+++ b/metrics-reporter/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.opensearchloadtester</groupId>
         <artifactId>opensearch-load-tester-parent</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.opensearchloadtester</groupId>
     <artifactId>opensearch-load-tester-parent</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1</version>
     <packaging>pom</packaging>
 
     <name>opensearch-load-tester-parent</name>

--- a/testdata-generator/pom.xml
+++ b/testdata-generator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.opensearchloadtester</groupId>
         <artifactId>opensearch-load-tester-parent</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testdata-generator/src/main/java/com/opensearchloadtester/testdatagenerator/model/duo/DuoDocument.java
+++ b/testdata-generator/src/main/java/com/opensearchloadtester/testdatagenerator/model/duo/DuoDocument.java
@@ -213,8 +213,8 @@ public class DuoDocument extends AbstractDocument {
               : null;
 
       List<Position> pos = new ArrayList<>();
-      // From examples always 0 positions
-      int numPos = RANDOM.nextInt(0, 1);
+      // Ensure positions exist so position-based queries return hits
+      int numPos = RANDOM.nextInt(1, 4);
       for (int i = 0; i < numPos; i++) {
         pos.add(Position.random());
       }

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.opensearchloadtester</groupId>
         <artifactId>opensearch-load-tester-parent</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Summary

## What changed

- Ensure DUO test data always includes positions by generating 1–3 positions per document, so position-based queries (q10) return hits.
- Bump project version from 6.0.0 to 6.0.1 across all module POMs.
- Update .env defaults to DUO data generation with 30k records and [custom-scenario.yaml](app://-/index.html#) for the load generator.

## Why

q10 queries were returning no results because positions were never generated in test data.
Version bump marks the fix.

## Testing

Manual verification via curl against local OpenSearch (q10 queries returned hits).
No automated tests run.